### PR TITLE
Remove refresh method from MapEntry

### DIFF
--- a/src/main/java/net/theevilreaper/aves/map/BaseMapEntry.java
+++ b/src/main/java/net/theevilreaper/aves/map/BaseMapEntry.java
@@ -57,14 +57,6 @@ public final class BaseMapEntry implements MapEntry {
     }
 
     /**
-     * Refreshes the map entry. It will check if the map file exists.
-     */
-    @Override
-    public void refresh() {
-        this.mapFilePath = this.directory.resolve(this.mapFileNaming);
-    }
-
-    /**
      * Checks if the map has a standard ending.
      *
      * @return {@code true} if the map has a standard ending

--- a/src/main/java/net/theevilreaper/aves/map/MapEntry.java
+++ b/src/main/java/net/theevilreaper/aves/map/MapEntry.java
@@ -50,13 +50,6 @@ public sealed interface MapEntry permits BaseMapEntry {
     void createFile();
 
     /**
-     * If the method is called the entry checks if the data file exists.
-     * This can be used to update the path references in special cases.
-     */
-    @Deprecated(forRemoval = true, since = "Please use createFile instead")
-    void refresh();
-
-    /**
      * Returns a boolean indicator if the given file which contains the data is the default
      *
      * @return true when the file is the default variant otherwise false


### PR DESCRIPTION
## Proposed changes

Some time ago, the `refresh` method in the `MapEntry` interface and its implementations was deprecated. The `createFile` method now updates the internal reference, making `refresh` unnecessary. This pull request removes the deprecated method.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)