### PR TITLE
feat(map): add teleportToSpawn method without instance set option

### DIFF
--- a/src/main/java/net/theevilreaper/aves/map/provider/MapProvider.java
+++ b/src/main/java/net/theevilreaper/aves/map/provider/MapProvider.java
@@ -41,10 +41,10 @@ public interface MapProvider {
 
     /**
      * Teleports a {@link Player} to the current active spawn position of the {@link Instance}.
-     * This method will not set the instance to the current active instance.
-     * If you want to set the instance to the current active instance, use {@link #teleportToSpawn(Player, boolean)}.
+     * This method does not change the player's instance.
+     * To also set the instance, use {@link #teleportToSpawn(Player, boolean)}.
      *
-     * @param player the player that should be teleported
+     * @param player to teleport
      */
     default void teleportToSpawn(@NotNull Player player) {
         teleportToSpawn(player, false);

--- a/src/main/java/net/theevilreaper/aves/map/provider/MapProvider.java
+++ b/src/main/java/net/theevilreaper/aves/map/provider/MapProvider.java
@@ -3,6 +3,7 @@ package net.theevilreaper.aves.map.provider;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.anvil.AnvilLoader;
 import net.theevilreaper.aves.map.BaseMap;
 import net.theevilreaper.aves.map.MapEntry;
 import org.jetbrains.annotations.NotNull;
@@ -16,7 +17,7 @@ import java.util.function.Supplier;
 /**
  * The {@link MapProvider} interface is responsible for managing the available maps.
  * It will load all maps data from the given path and store them.
- * It would not load the map itself over a {@link net.minestom.server.instance.anvil.AnvilLoader} instance.
+ * It would not load the map itself over a {@link AnvilLoader} instance.
  * This behavior is handled by another class.
  *
  * @author theEvilReaper
@@ -26,7 +27,7 @@ import java.util.function.Supplier;
 public interface MapProvider {
 
     /**
-     * A static fallback position which can be used if no spawn position is set.
+     * A static fallback position that can be used if no spawn position is set.
      */
     Pos FALLBACK_POS = new Pos(0, 100, 0);
 
@@ -34,14 +35,25 @@ public interface MapProvider {
      * Saves the given data from a {@link BaseMap} to the given path.
      *
      * @param path    the path where the map data should be saved
-     * @param baseMap the map data which should be saved
+     * @param baseMap the map data that should be saved
      */
     void saveMap(@NotNull Path path, @NotNull BaseMap baseMap);
 
     /**
      * Teleports a {@link Player} to the current active spawn position of the {@link Instance}.
+     * This method will not set the instance to the current active instance.
+     * If you want to set the instance to the current active instance, use {@link #teleportToSpawn(Player, boolean)}.
      *
-     * @param player      the player which should be teleported
+     * @param player the player that should be teleported
+     */
+    default void teleportToSpawn(@NotNull Player player) {
+        teleportToSpawn(player, false);
+    }
+
+    /**
+     * Teleports a {@link Player} to the current active spawn position of the {@link Instance}.
+     *
+     * @param player      the player that should be teleported
      * @param instanceSet if the instance should be set to the current active instance
      */
     void teleportToSpawn(@NotNull Player player, boolean instanceSet);

--- a/src/test/java/net/theevilreaper/aves/map/provider/MapProviderIntegrationTest.java
+++ b/src/test/java/net/theevilreaper/aves/map/provider/MapProviderIntegrationTest.java
@@ -114,7 +114,7 @@ class MapProviderIntegrationTest {
 
         assertEquals(Pos.ZERO, player.getPosition());
 
-        mapProvider.teleportToSpawn(player, false);
+        mapProvider.teleportToSpawn(player);
 
         assertNotEquals(Pos.ZERO, player.getPosition());
 


### PR DESCRIPTION
## Proposed changes

This pull request adds an overload of the teleportToSpawn method without the setInstance parameter.
By default, this method does not change the player's instance. This also allows the method to be used as a method 
reference.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)