### PR TITLE
fix(items): optimize inventory checks and fix free space calculation

### DIFF
--- a/src/main/java/net/theevilreaper/aves/util/Items.java
+++ b/src/main/java/net/theevilreaper/aves/util/Items.java
@@ -4,50 +4,62 @@ import net.minestom.server.entity.Player;
 import net.minestom.server.item.ItemStack;
 
 /**
- * The class contains some methods to work with {@link ItemStack}.
+ * Utility class providing helper methods to work with {@link ItemStack} and player inventories.
+ *
  * @author theEvilReaper
+ * @version 1.2.0
  * @since 1.0.6
- * @version 1.0.0
  */
 public final class Items {
 
     public static final int MAX_STACK_SIZE = 64;
 
-    private Items() {}
+    private Items() {
+    }
 
     /**
-     * Returns the number of a specific item that is in a player's inventory
-     * @param player The player to be appointed by
-     * @param item The item to check
-     * @return The amount of the given item but returns with zero when the item does not occur in the inventory
+     * Returns the number of a specific item in a player's inventory.
+     * <p>
+     * Item similarity is checked via {@link ItemStack#isSimilar(ItemStack)}.
+     *
+     * @param player whose inventory to inspect
+     * @param item   to count
+     * @return the total amount of matching items found, or 0 if none exist
      */
     public static int getAmountFromItem(Player player, ItemStack item) {
         int amount = 0;
-        if (player.getInventory().getItemStacks().length != 0) {
-            for (int i = 0; i < player.getInventory().getItemStacks().length; i++) {
-                if (player.getInventory().getItemStacks()[i].isSimilar(item)) {
-                    amount += player.getInventory().getItemStacks()[i].amount();
-                }
+        ItemStack[] itemStacks = player.getInventory().getItemStacks();
+        for (ItemStack currentStack : itemStacks) {
+            if (currentStack.isSimilar(item)) {
+                amount += currentStack.amount();
             }
         }
         return amount;
     }
 
     /**
-     * Returns the remaining free space in the inventory of a given player.
-     * @param player The player from which the remaining place should be determined
-     * @return The amount of free space
+     * Returns the remaining free space in a player's inventory.
+     * <p>
+     * Empty slots count as having 64 free slots. Non-empty slots calculate free space based on
+     * the item's specific {@link ItemStack#maxStackSize()}.
+     *
+     * @param player whose inventory capacity to determine
+     * @return the total remaining item space available across all slots
      */
     public static int getFreeSpace(Player player) {
         int spaceCount = 0;
-        for (int i = 0; i < player.getInventory().getSize(); i++) {
-            var currentStack = player.getInventory().getItemStacks()[i];
-            if (currentStack.material() == ItemStack.AIR.material()) {
+        ItemStack[] itemStacks = player.getInventory().getItemStacks();
+        int inventorySize = player.getInventory().getSize();
+
+        for (int i = 0; i < inventorySize && i < itemStacks.length; i++) {
+            ItemStack currentStack = itemStacks[i];
+            if (currentStack.isAir()) {
                 spaceCount += MAX_STACK_SIZE;
                 continue;
             }
 
-            spaceCount += MAX_STACK_SIZE - currentStack.amount();
+            int maxStackSize = currentStack.maxStackSize();
+            spaceCount += Math.max(0, maxStackSize - currentStack.amount());
         }
         return spaceCount;
     }

--- a/src/test/java/net/theevilreaper/aves/util/ItemsIntegrationTest.java
+++ b/src/test/java/net/theevilreaper/aves/util/ItemsIntegrationTest.java
@@ -31,6 +31,24 @@ class ItemsIntegrationTest {
     }
 
     @Test
+    void testFreeSpaceWithNonStandardMaxStackSize(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        // Slot 0 has 10 Ender Pearls (max stack size 16 -> remaining space in slot 0 is 6)
+        player.getInventory().setItemStack(0, ItemStack.of(Material.ENDER_PEARL, 10));
+
+        // Slot 1 has 1 Diamond Sword (max stack size 1 -> remaining space in slot 1 is 0)
+        player.getInventory().setItemStack(1, ItemStack.of(Material.DIAMOND_SWORD, 1));
+
+        // Remaining empty slots have (size - 2) * 64 space
+        int expectedFreeSpace = ((player.getInventory().getSize() - 2) * Items.MAX_STACK_SIZE) + (16 - 10) + (1 - 1);
+        assertEquals(expectedFreeSpace, Items.getFreeSpace(player));
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
     void testGetItemAmountFrom(@NotNull Env env) {
         Instance instance = env.createFlatInstance();
         Player player = env.createPlayer(instance);


### PR DESCRIPTION
## Proposed changes

This PR refactors the `Items` utility class to improve performance and correctness when analyzing player inventories.

Previously, `getAmountFromItem` and `getFreeSpace` queried the inventory array repeatedly during loop iterations, creating unnecessary overhead. Additionally, `getFreeSpace` assumed all non-empty slots had a maximum stack size of 64, which led to incorrect free space calculations for items with custom stack limits such as Ender Pearls or unstackable tools and armor

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)